### PR TITLE
Fix to Issue 'game crashes on bespin_platform boss fight'.

### DIFF
--- a/code/game/q_shared.h
+++ b/code/game/q_shared.h
@@ -721,7 +721,7 @@ inline int Q_irand(int min, int max) {
 	
 	//int r= ((rand() /(RAND_MAX/(max-min)) ))+min;
 	//printf("Q_irand: min=%d, max=%d, r=%d\n", min, max, r);
-	return ((rand() /(RAND_MAX/(max-min)) ))+min;
+	return ((rand() * (max-min) / RAND_MAX ))+min;
 }
 
 //returns a float between 0 and 1.0


### PR DESCRIPTION
This was causes by a 'Division by 0 on Q_irand
