### PR TITLE
fix multiply defined symbol error in lucid

### DIFF
--- a/code/mp3code/towave.c
+++ b/code/mp3code/towave.c
@@ -152,10 +152,11 @@ decode (standard decoder) reduction_code:
 #include <assert.h>
 
 
+#ifndef LINUX
 #ifndef byte
 typedef unsigned char byte;
 #endif
-
+#endif
 
 
 typedef struct id3v1_1 {


### PR DESCRIPTION
Nice work!

I had to make one small change to get it to compile on Lucid; it looks like the #ifdef byte didn't detect the typedef, so that was multiply defined. 
