### PR TITLE
initialize correct min var, so spawn picking works

### DIFF
--- a/code/game/g_cmds.cpp
+++ b/code/game/g_cmds.cpp
@@ -804,7 +804,7 @@ qboolean PickSeekerSpawnPoint( vec3_t org, vec3_t fwd, vec3_t right, int skip, v
 	vec3_t	mins, maxs, forward, end;
 	trace_t tr;
 
-	VectorSet( maxs, -8, -8, -24); // ?? size
+	VectorSet( mins, -8, -8, -24); // ?? size
 	VectorSet( maxs, 8, 8, 8 );
 
 	VectorCopy( fwd, forward );


### PR DESCRIPTION
I found the problem with the seeker drone; instead of initializing mins & maxs, it was setting maxs twice.
