### PR TITLE
Fix weapons to follow weapon view yaw when tracked to hands.

### DIFF
--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -790,24 +790,23 @@ void CG_CalculateWeaponPosition( vec3_t origin, vec3_t angles )
 	VectorCopy( cg.refdefViewAnglesWeapon, angles );
 
 	// [shinyquagsire23] Change weapon position to match hands
-	vec3_t vrR;
 	float vrRX = 0, vrRY = 0, vrRZ = 0;
 	float vrRRoll = 0, vrRYaw = 0, vrRPitch = 0;
 	if (GameHmd::Get()->GetRightHandOrientation(vrRPitch, vrRYaw, vrRRoll) && GameHmd::Get()->GetRightHandPosition(vrRX, vrRY, vrRZ))
 	{
+		vec3_t viewaxisWeapon[3];
+
 		float c = cos(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
 		float s = sin(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
+		AnglesToAxis(cg.refdefViewAnglesWeapon, viewaxisWeapon);
 
-		vrR[0] = -(vrRX * c - vrRY * s);
-		vrR[1] = -(vrRX * s + vrRY * c);
-		vrR[2] = -vrRZ;
+		VectorMA(origin, -(vrRX * c - vrRY * s), viewaxisWeapon[0], origin);
+		VectorMA(origin, -(vrRX * s + vrRY * c), viewaxisWeapon[1], origin);
+		VectorMA(origin, -vrRZ, viewaxisWeapon[2], origin);
 
 		angles[PITCH] = vrRPitch;
 		angles[YAW] += vrRYaw;
 		angles[ROLL] = vrRRoll;
-		
-		//Com_Printf("%f %f %f\n", c, s, cg.refdefViewAnglesWeapon[YAW]);
-		VectorAdd(origin, vrR, origin);
 	}
 	else
 	{

--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -795,13 +795,19 @@ void CG_CalculateWeaponPosition( vec3_t origin, vec3_t angles )
 	if (GameHmd::Get()->GetRightHandOrientation(vrRPitch, vrRYaw, vrRRoll) && GameHmd::Get()->GetRightHandPosition(vrRX, vrRY, vrRZ))
 	{
 		vec3_t viewaxisWeapon[3];
+		vec3_t viewAnglesWeapon;
 
 		float c = cos(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
 		float s = sin(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
-		AnglesToAxis(cg.refdefViewAnglesWeapon, viewaxisWeapon);
 
-		VectorMA(origin, -(vrRX * c - vrRY * s), viewaxisWeapon[0], origin);
-		VectorMA(origin, -(vrRX * s + vrRY * c), viewaxisWeapon[1], origin);
+		// Get our weapon view angles to use for adjusting our hand position
+		VectorCopy(cg.refdefViewAnglesWeapon, viewAnglesWeapon);
+		viewAnglesWeapon[PITCH] = 0.0f;
+		viewAnglesWeapon[ROLL] = 0.0f;
+		AnglesToAxis(viewAnglesWeapon, viewaxisWeapon);
+
+		VectorMA(origin, (vrRX * c - vrRY * s), viewaxisWeapon[0], origin);
+		VectorMA(origin, (vrRX * s + vrRY * c), viewaxisWeapon[1], origin);
 		VectorMA(origin, -vrRZ, viewaxisWeapon[2], origin);
 
 		angles[PITCH] = vrRPitch;


### PR DESCRIPTION
Hopefully this should be just about everything that's kinda game-breaking as far as weapon tracking goes, I think what happened is that my code to compensate for yaw was just built on the same bad assumptions which made rotation borked before.