### PR TITLE
Keep refdefViewAnglesWeapon constant when tracking weapons to hands

### DIFF
--- a/code/cgame/cg_view.cpp
+++ b/code/cgame/cg_view.cpp
@@ -1775,6 +1775,14 @@ static qboolean CG_CalcViewValues( void ) {
         cg.refdefViewAngles[ROLL] = roll;
         cg.refdefViewAngles[PITCH] = pitch;
         cg.refdefViewAngles[YAW] = yaw + inputYaw + SHORT2ANGLE(ps->delta_angles[YAW]);
+
+        // We need our weapon angles to be consistent so the camera rotation 
+        // doesn't screw over our position tracking.
+        if (GameHmd::Get()->HasHands())
+        {
+            cg.refdefViewAnglesWeapon[PITCH] = 0.0f;
+            cg.refdefViewAnglesWeapon[YAW] = inputYaw + SHORT2ANGLE(ps->delta_angles[YAW]);
+        }
     }
 
 	float x, y, z;

--- a/code/hmd/ClientHmd.cpp
+++ b/code/hmd/ClientHmd.cpp
@@ -92,7 +92,7 @@ void ClientHmd::UpdateInputView(float yawDiff, float pitchDiff, float& rPitch, f
     // we need to keep render orientation and input orientation the same
     GetOrientation(pitch, yaw, roll);
 
-    if (hmd_decoupleAim->integer || HasHand(true))
+    if (hmd_decoupleAim->integer)
     {
         mViewanglePitchDiff += pitchDiff;
         mViewanglePitchDiff += (mLastPitch - pitch);


### PR DESCRIPTION
Allows hmd_decoupleAim to not be forced when using hands since the weapon view is kept constant.

[Video of PR changes](https://www.youtube.com/watch?v=IJVZ7gKMnjI), where I start off with decoupled aiming and then turn it off to allow move-where-you-look.