### PR TITLE
Allow tracking of lightsaber to right hand

### DIFF
--- a/code/game/g_public.h
+++ b/code/game/g_public.h
@@ -251,6 +251,9 @@ qboolean	(*G2API_StopBoneAnim)(CGhoul2Info *ghlInfo, const char *boneName);
 qboolean	(*G2API_SetBoneAngles)(CGhoul2Info *ghlInfo, const char *boneName, const vec3_t angles,
 								   const int flags, const Eorientations up, const Eorientations right, const Eorientations forward,
 								   qhandle_t *modelList, int blendTime, int blendStart);
+qboolean	(*G2API_SetBoneAnglesOffset)(CGhoul2Info *ghlInfo, const char *boneName, const vec3_t angles, const int flags,
+								   const Eorientations up, const Eorientations left, const Eorientations forward, qhandle_t *modelList,
+								   int blendTime, int AcurrentTime, const vec3_t offset);
 qboolean	(*G2API_SetBoneAnglesMatrix)(CGhoul2Info *ghlInfo, const char *boneName, const mdxaBone_t &matrix, const int flags,
 									  qhandle_t *modelList, int blendTime, int currentTime);
 qboolean	(*G2API_StopBoneAngles)(CGhoul2Info *ghlInfo, const char *boneName);

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5212,7 +5212,7 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 	// [shinyquagsire23] Unbolt the saber if we have hands and control it manually
 	if (self->weaponModel != -1 && self->s.number == 0)
 	{
-		if (GameHmd::Get()->HasHands())
+		if (GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
 		{
 			vec3_t viewaxisWeapon[3];
 			vec3_t viewAnglesWeapon;
@@ -5243,6 +5243,9 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 		}
 		else
 		{
+			vec3_t zero = { 0.0f, 0.0f, 0.0f };
+
+			gi.G2API_SetBoneAnglesOffset(&self->ghoul2[self->weaponModel], "ModView internal default", zero, BONE_ANGLES_PREMULT, POSITIVE_X, NEGATIVE_Y, NEGATIVE_Z, NULL, 0, 0, zero);
 			gi.G2API_AttachG2Model(&self->ghoul2[self->weaponModel], &self->ghoul2[self->playerModel],
 				self->handRBolt, self->playerModel);
 		}

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5187,6 +5187,27 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 	{
 		return;
 	}
+	
+	if ( self->client->ps.saberEntityNum < 0 || self->client->ps.saberEntityNum >= ENTITYNUM_WORLD )
+	{//never got one
+		return;
+	}
+
+	// Check if we are throwing it, launch it if needed, update position if needed.
+	WP_SaberThrow(self, ucmd);
+
+
+	//vec3_t saberloc;
+	//vec3_t sabermins={-8,-8,-8}, sabermaxs={8,8,8};
+
+	gentity_t *saberent;
+	
+	if (self->client->ps.saberEntityNum <= 0)
+	{//WTF?!!  We lost it?
+		return;
+	}
+
+	saberent = &g_entities[self->client->ps.saberEntityNum];
 
 	// [shinyquagsire23] Unbolt the saber if we have hands and control it manually
 	if (self->weaponModel != -1 && self->s.number == 0)
@@ -5222,31 +5243,10 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 		}
 		else
 		{
-			gi.G2API_AttachG2Model(&self->ghoul2[self->weaponModel], &self->ghoul2[self->playerModel], 
-						self->handRBolt, self->playerModel);
+			gi.G2API_AttachG2Model(&self->ghoul2[self->weaponModel], &self->ghoul2[self->playerModel],
+				self->handRBolt, self->playerModel);
 		}
 	}
-	
-	if ( self->client->ps.saberEntityNum < 0 || self->client->ps.saberEntityNum >= ENTITYNUM_WORLD )
-	{//never got one
-		return;
-	}
-
-	// Check if we are throwing it, launch it if needed, update position if needed.
-	WP_SaberThrow(self, ucmd);
-
-
-	//vec3_t saberloc;
-	//vec3_t sabermins={-8,-8,-8}, sabermaxs={8,8,8};
-
-	gentity_t *saberent;
-	
-	if (self->client->ps.saberEntityNum <= 0)
-	{//WTF?!!  We lost it?
-		return;
-	}
-
-	saberent = &g_entities[self->client->ps.saberEntityNum];
 
 	//FIXME: Based on difficulty level/jedi saber combat skill, make this bounding box fatter/smaller
 	if ( self->client->ps.saberBlocked != BLOCKED_NONE )

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5207,7 +5207,7 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 			// Rotate our weapon's position to be set up properly
 			viewAnglesWeapon[PITCH] = 0.0f;
 			viewAnglesWeapon[ROLL] = 0.0f;
-			viewAnglesWeapon[YAW] = -90.0f- (self->client->renderInfo.legsYaw - self->currentAngles[YAW]);
+			viewAnglesWeapon[YAW] = -90.0f + cg_entities[self->s.number].pe.torso.yawAngle;
 			AnglesToAxis(viewAnglesWeapon, viewaxisWeapon);
 
 			VectorMA(pos, -(vrR_pos[0] * c - vrR_pos[1] * s), viewaxisWeapon[0], pos);

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5214,7 +5214,11 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 			VectorMA(pos, -(vrR_pos[0] * s + vrR_pos[1] * c), viewaxisWeapon[1], pos);
 			VectorMA(pos, -vrR_pos[2], viewaxisWeapon[2], pos);
 
-			gi.G2API_SetBoneAnglesOffset(&self->ghoul2[self->weaponModel], "ModView internal default", vrR_rot, BONE_ANGLES_PREMULT, POSITIVE_X, NEGATIVE_Y, NEGATIVE_Z, NULL, 0, 0, pos);
+			rot[PITCH] = vrR_rot[PITCH];
+			rot[YAW] = vrR_rot[PITCH];
+			rot[ROLL] = vrR_rot[YAW] - 45.0f; //TODO: This is probably dependent on the tag?
+
+			gi.G2API_SetBoneAnglesOffset(&self->ghoul2[self->weaponModel], "ModView internal default", rot, BONE_ANGLES_PREMULT, POSITIVE_X, NEGATIVE_Y, NEGATIVE_Z, NULL, 0, 0, pos);
 		}
 		else
 		{

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5204,15 +5204,15 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 			float c = cos(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
 			float s = sin(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
 
-			// Get our weapon view angles to use for adjusting our hand position
+			// Rotate our weapon's position to be set up properly
 			viewAnglesWeapon[PITCH] = 0.0f;
 			viewAnglesWeapon[ROLL] = 0.0f;
-			viewAnglesWeapon[YAW] = cg.refdefViewAnglesWeapon[YAW] - 90.0f;
+			viewAnglesWeapon[YAW] = -90.0f- (self->client->renderInfo.legsYaw - self->currentAngles[YAW]);
 			AnglesToAxis(viewAnglesWeapon, viewaxisWeapon);
 
 			VectorMA(pos, -(vrR_pos[0] * c - vrR_pos[1] * s), viewaxisWeapon[0], pos);
 			VectorMA(pos, -(vrR_pos[0] * s + vrR_pos[1] * c), viewaxisWeapon[1], pos);
-			VectorMA(pos, -vrR_pos[2], viewaxisWeapon[2], pos);
+			VectorMA(pos, -vrR_pos[2] + (cg.refdef.vieworg[2] - self->currentOrigin[2]), viewaxisWeapon[2], pos);
 
 			rot[PITCH] = vrR_rot[PITCH];
 			rot[YAW] = vrR_rot[PITCH];

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5237,7 +5237,7 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 
 			rot[PITCH] = vrR_rot[PITCH];
 			rot[YAW] = vrR_rot[PITCH];
-			rot[ROLL] = vrR_rot[YAW] - 45.0f; //TODO: This is probably dependent on the tag?
+			rot[ROLL] = vrR_rot[YAW] - 45.0f + cg_entities[self->s.number].pe.torso.yawAngle; //TODO: This is probably dependent on the tag?
 
 			gi.G2API_SetBoneAnglesOffset(&self->ghoul2[self->weaponModel], "ModView internal default", rot, BONE_ANGLES_PREMULT, POSITIVE_X, NEGATIVE_Y, NEGATIVE_Z, NULL, 0, 0, pos);
 		}

--- a/code/ghoul2/G2.h
+++ b/code/ghoul2/G2.h
@@ -32,7 +32,7 @@ int			G2_IsSurfaceRendered(CGhoul2Info *ghlInfo, const char *surfaceName, surfac
 // internal bone calls - G2_Bones.cpp
 qboolean	G2_Set_Bone_Angles(CGhoul2Info *ghlInfo, boneInfo_v &blist, const char *boneName, const float *angles, const int flags,
 							   const Eorientations up, const Eorientations left, const Eorientations forward,
-							   const int blendTime, const int currentTime);
+							   const int blendTime, const int currentTime, const vec3_t offset);
 qboolean	G2_Remove_Bone (CGhoul2Info *ghlInfo, boneInfo_v &blist, const char *boneName);
 qboolean	G2_Set_Bone_Anim(CGhoul2Info *ghlInfo, boneInfo_v &blist, const char *boneName, const int startFrame, 
 							 const int endFrame, const int flags, const float animSpeed, const int currentTime, const float setFrame, const int blendTime);
@@ -54,7 +54,7 @@ int			G2_Get_Bone_Index(CGhoul2Info *ghoul2, const char *boneName, qboolean bAdd
 qboolean	G2_Set_Bone_Angles_Index(CGhoul2Info *ghlInfo, boneInfo_v &blist, const int index,
 							const float *angles, const int flags, const Eorientations yaw,
 							const Eorientations pitch, const Eorientations roll,
-							const int blendTime, const int currentTime);
+							const int blendTime, const int currentTime, const vec3_t offset);
 qboolean	G2_Set_Bone_Angles_Matrix_Index(boneInfo_v &blist, const int index,
 								   const mdxaBone_t &matrix, const int flags, 
 								   const int blendTime, const int currentTime);
@@ -116,6 +116,9 @@ qboolean	G2API_StopBoneAnim(CGhoul2Info *ghlInfo, const char *boneName);
 qboolean	G2API_SetBoneAngles(CGhoul2Info *ghlInfo, const char *boneName, const vec3_t angles, const int flags,
 								const Eorientations up, const Eorientations right, const Eorientations forward, qhandle_t *modelList,
 								int blendTime = 0, int currentTime = 0);
+qboolean	G2API_SetBoneAnglesOffset(CGhoul2Info *ghlInfo, const char *boneName, const vec3_t angles, const int flags,
+								const Eorientations up, const Eorientations right, const Eorientations forward, qhandle_t *modelList,
+								int blendTime = 0, int currentTime = 0, const vec3_t offset = NULL);
 qboolean	G2API_StopBoneAngles(CGhoul2Info *ghlInfo, const char *boneName);
 qboolean	G2API_RemoveBone(CGhoul2Info *ghlInfo, const char *boneName);
 qboolean	G2API_RemoveBolt(CGhoul2Info *ghlInfo, const int index);

--- a/code/ghoul2/G2_API.cpp
+++ b/code/ghoul2/G2_API.cpp
@@ -954,9 +954,9 @@ qboolean G2API_StopBoneAnim(CGhoul2Info *ghlInfo, const char *boneName)
 	return ret;
 }
 
-qboolean G2API_SetBoneAnglesIndex(CGhoul2Info *ghlInfo, const int index, const vec3_t angles, const int flags,
+qboolean G2API_SetBoneAnglesOffsetIndex(CGhoul2Info *ghlInfo, const int index, const vec3_t angles, const int flags,
 							 const Eorientations yaw, const Eorientations pitch, const Eorientations roll,
-							 qhandle_t *, int blendTime, int AcurrentTime)
+							 qhandle_t *, int blendTime, int AcurrentTime, const vec3_t offset)
 {
 	qboolean ret=qfalse;
 	if (G2_SetupModelPointers(ghlInfo))
@@ -967,16 +967,23 @@ qboolean G2API_SetBoneAnglesIndex(CGhoul2Info *ghlInfo, const int index, const v
 		G2ERROR(index>=0&&index<ghlInfo->mBlist.size(),"G2API_SetBoneAnglesIndex:Invalid bone index");
 		if (index>=0&&index<ghlInfo->mBlist.size())
 		{
-			ret=G2_Set_Bone_Angles_Index(ghlInfo, ghlInfo->mBlist, index, angles, flags, yaw, pitch, roll,blendTime, currentTime);
+			ret=G2_Set_Bone_Angles_Index(ghlInfo, ghlInfo->mBlist, index, angles, flags, yaw, pitch, roll,blendTime, currentTime, offset);
 		}
 	}
 	G2WARNING(ret,"G2API_SetBoneAnglesIndex Failed");
 	return ret;
 }
 
-qboolean G2API_SetBoneAngles(CGhoul2Info *ghlInfo, const char *boneName, const vec3_t angles, const int flags,
+qboolean G2API_SetBoneAnglesIndex(CGhoul2Info *ghlInfo, const int index, const vec3_t angles, const int flags,
+							 const Eorientations yaw, const Eorientations pitch, const Eorientations roll,
+							 qhandle_t *, int blendTime, int AcurrentTime)
+{
+	return G2API_SetBoneAnglesOffsetIndex(ghlInfo, index, angles, flags, yaw, pitch, roll, 0, blendTime, AcurrentTime, NULL);
+}
+
+qboolean G2API_SetBoneAnglesOffset(CGhoul2Info *ghlInfo, const char *boneName, const vec3_t angles, const int flags,
 							 const Eorientations up, const Eorientations left, const Eorientations forward,
-							 qhandle_t *, int blendTime, int AcurrentTime )
+							 qhandle_t *, int blendTime, int AcurrentTime, const vec3_t offset )
 {
 	qboolean ret=qfalse;
 	G2ERROR(boneName,"NULL boneName");
@@ -985,10 +992,17 @@ qboolean G2API_SetBoneAngles(CGhoul2Info *ghlInfo, const char *boneName, const v
 		int currentTime=G2API_GetTime(AcurrentTime);
 			// ensure we flush the cache
 		ghlInfo->mSkelFrameNum = 0;
-		ret=G2_Set_Bone_Angles(ghlInfo, ghlInfo->mBlist, boneName, angles, flags, up, left, forward, blendTime, currentTime);
+		ret=G2_Set_Bone_Angles(ghlInfo, ghlInfo->mBlist, boneName, angles, flags, up, left, forward, blendTime, currentTime, offset);
 	}
 	G2WARNING(ret,"G2API_SetBoneAngles Failed");
 	return ret;
+}
+
+qboolean G2API_SetBoneAngles(CGhoul2Info *ghlInfo, const char *boneName, const vec3_t angles, const int flags,
+							 const Eorientations up, const Eorientations left, const Eorientations forward,
+							 qhandle_t *, int blendTime, int AcurrentTime )
+{
+	return G2API_SetBoneAnglesOffset(ghlInfo, boneName, angles, flags, up, left, forward, 0, blendTime, AcurrentTime, NULL);
 }
 
 qboolean G2API_SetBoneAnglesMatrixIndex(CGhoul2Info *ghlInfo, const int index, const mdxaBone_t &matrix,

--- a/code/ghoul2/G2_bones.cpp
+++ b/code/ghoul2/G2_bones.cpp
@@ -205,7 +205,7 @@ qboolean G2_Stop_Bone_Index( boneInfo_v &blist, int index, int flags)
 
 // generate a matrix for a given bone given some new angles for it.
 void G2_Generate_Matrix(const model_t *mod, boneInfo_v &blist, int index, const float *angles, int flags,
-						const Eorientations up, const Eorientations left, const Eorientations forward)
+						const Eorientations up, const Eorientations left, const Eorientations forward, const vec3_t offset = NULL)
 {
 	mdxaSkel_t		*skel;
 	mdxaSkelOffsets_t *offsets;
@@ -290,6 +290,13 @@ void G2_Generate_Matrix(const model_t *mod, boneInfo_v &blist, int index, const 
 
 		Create_Matrix(newAngles, boneOverride);
 
+		if (offset)
+		{
+			boneOverride->matrix[0][3] = offset[0];
+			boneOverride->matrix[1][3] = offset[1];
+			boneOverride->matrix[2][3] = offset[2];
+		}
+
 		// figure out where the bone hirearchy info is
 		offsets = (mdxaSkelOffsets_t *)((byte *)mod->mdxa + sizeof(mdxaHeader_t));
 		skel = (mdxaSkel_t *)((byte *)mod->mdxa + sizeof(mdxaHeader_t) + offsets->offsets[blist[index].boneNumber]);
@@ -309,6 +316,13 @@ void G2_Generate_Matrix(const model_t *mod, boneInfo_v &blist, int index, const 
 		}
 
 		Create_Matrix(newAngles, &temp1);
+
+		if (offset)
+		{
+			temp1.matrix[0][3] = offset[0];
+			temp1.matrix[1][3] = offset[1];
+			temp1.matrix[2][3] = offset[2];
+		}
 
 		permutation.matrix[0][0] = permutation.matrix[0][1] = permutation.matrix[0][2] = permutation.matrix[0][3] = 0;
 		permutation.matrix[1][0] = permutation.matrix[1][1] = permutation.matrix[1][2] = permutation.matrix[1][3] = 0;
@@ -414,7 +428,7 @@ qboolean G2_Remove_Bone (CGhoul2Info *ghlInfo, boneInfo_v &blist, const char *bo
 qboolean G2_Set_Bone_Angles_Index(CGhoul2Info *ghlInfo, boneInfo_v &blist, const int index,
 							const float *angles, const int flags, const Eorientations yaw,
 							const Eorientations pitch, const Eorientations roll,
-							const int blendTime, const int currentTime)
+							const int blendTime, const int currentTime, const vec3_t offset)
 {
 	
 	if (index<0||(index >= blist.size()) || (blist[index].boneNumber == -1))
@@ -430,7 +444,7 @@ qboolean G2_Set_Bone_Angles_Index(CGhoul2Info *ghlInfo, boneInfo_v &blist, const
 #if DEBUG_PCJ
 	OutputDebugString(va("%8x  %2d %6d   (%6.2f,%6.2f,%6.2f) %d %d %d %d\n",(int)ghlInfo,index,currentTime,angles[0],angles[1],angles[2],yaw,pitch,roll,flags));
 #endif
-	G2_Generate_Matrix(ghlInfo->animModel, blist, index, angles, flags, yaw, pitch, roll);
+	G2_Generate_Matrix(ghlInfo->animModel, blist, index, angles, flags, yaw, pitch, roll, offset);
 	return qtrue;
 
 }
@@ -438,7 +452,7 @@ qboolean G2_Set_Bone_Angles_Index(CGhoul2Info *ghlInfo, boneInfo_v &blist, const
 // Given a model handle, and a bone name, we want to set angles specifically for overriding
 qboolean G2_Set_Bone_Angles(CGhoul2Info *ghlInfo, boneInfo_v &blist, const char *boneName, const float *angles,
 							const int flags, const Eorientations up, const Eorientations left, const Eorientations forward,
-							const int blendTime, const int currentTime)
+							const int blendTime, const int currentTime, const vec3_t offset)
 {
 	int			index = G2_Find_Bone(ghlInfo, blist, boneName);
 	if (index == -1)
@@ -452,7 +466,7 @@ qboolean G2_Set_Bone_Angles(CGhoul2Info *ghlInfo, boneInfo_v &blist, const char 
 		blist[index].boneBlendStart = currentTime;
 		blist[index].boneBlendTime = blendTime;
 
-		G2_Generate_Matrix(ghlInfo->animModel, blist, index, angles, flags, up, left, forward);
+		G2_Generate_Matrix(ghlInfo->animModel, blist, index, angles, flags, up, left, forward, offset);
 		return qtrue;
 	}
 	return qfalse;

--- a/code/server/sv_game.cpp
+++ b/code/server/sv_game.cpp
@@ -424,6 +424,7 @@ Ghoul2 Insert Start
 	import.G2API_RemoveBone = G2API_RemoveBone;
 	import.G2API_RemoveGhoul2Model = G2API_RemoveGhoul2Model;
 	import.G2API_SetBoneAngles = G2API_SetBoneAngles;
+	import.G2API_SetBoneAnglesOffset = G2API_SetBoneAnglesOffset;
 	import.G2API_SetBoneAnglesMatrix = G2API_SetBoneAnglesMatrix;
 	import.G2API_SetBoneAnim = G2API_SetBoneAnim;
 	import.G2API_SetLodBias = G2API_SetLodBias;


### PR DESCRIPTION
This PR is probably going to take a while so don't pull just yet since there's still things to work out.

Lightsaber tracking is effectively done by extending the Ghoul2 API, which might seem like a roundabout way of doing things but I'd argue it's probably the cleanest way. By detaching the lightsaber model from the right hand bolt, its position defaults to underneath the player's head centered at the bottom of the player collision box. The blade is always attached to the lightsaber model regardless of where it's bolted or not bolted to, and collisions match the saber as it should, which might actually end up making a JKA port a bit easier for things like double-bladed sabers or dual sabers.

With the lightsaber upright and underneath the player, it can be offset and rotated to match the hand position. This seems to work well with g_saberRealisticCombat set to 1, or by using primary fire to increase the saber damage on collision. A video of this as of the first commit can be seen [here](https://www.youtube.com/watch?v=SFITWdk0OU0).

**Current Issues**

- ~~The position is probably off, the lightsaber goes under the floor in my tests which doesn't currently match up with the behavior I have with weapons I don't think.~~ Position is better I think but might still be off.
- ~~Rotation axis are swapped relative to the tag used to bolt the saber to the right hand~~
- ~~When strafing, the rotation added by the animation also rotates the saber in space~~ Kinda fixed, but looking for a nicer fix.