### PR TITLE
Track lightsaber to right hand in first-person mode

### DIFF
--- a/code/cgame/cg_ents.cpp
+++ b/code/cgame/cg_ents.cpp
@@ -568,7 +568,7 @@ const weaponData_t  *wData = NULL;
 				//light?  sound?
 				if ( cent->gent->owner->client && cg_entities[cent->currentState.otherEntityNum].currentState.saberActive )
 				{//saber is in-flight and active, play a sound on it
-					if ( cent->gent->owner->client->ps.saberEntityState == SES_RETURNING )
+					if ( cent->gent->owner->client->ps.saberEntityState == SES_RETURNING || cent->gent->owner->client->ps.saberEntityState == SES_OVERRIDE )
 					{
 						cgi_S_AddLoopingSound( cent->currentState.number, 
 							cent->lerpOrigin, vec3_origin, 

--- a/code/cgame/cg_players.cpp
+++ b/code/cgame/cg_players.cpp
@@ -5082,7 +5082,7 @@ Ghoul2 Insert Start
 			{//no viewentity
 				if ( cent->currentState.number == cg.snap->ps.clientNum )
 				{//I am the player
-					if ( cg.snap->ps.weapon != WP_SABER && cg.snap->ps.weapon != WP_MELEE )
+					if ( (cg.snap->ps.weapon != WP_SABER && cg.snap->ps.weapon != WP_MELEE) || GameHmd::Get()->HasHands() )
 					{//not using saber or fists
 						ent.renderfx = RF_THIRD_PERSON;			// only draw in mirrors
 					}

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5228,6 +5228,7 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 			GameHmd::Get()->GetRightHandOrientation(vrR_rot[PITCH], vrR_rot[YAW], vrR_rot[ROLL]);
 			GameHmd::Get()->GetRightHandPosition(vrR_pos[0], vrR_pos[1], vrR_pos[2]);
 			vrR_rot[YAW] += cg.refdefViewAnglesWeapon[YAW];
+			vrR_rot[PITCH] += 45.0f; //TODO: Have GameHmd handle transforms for guns vs sabers? Controller grip depends on the headset.
 
 			// Rotate saber to be in front of weapon view at all times
 			viewAnglesWeapon[PITCH] = 0.0f;

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5253,7 +5253,7 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 
 			// We're hovering, but not in a saber throw.
 			self->client->ps.saberInFlight = qfalse;
-			self->client->ps.saberEntityState = SES_HOVERING;
+			self->client->ps.saberEntityState = SES_OVERRIDE;
 			self->client->ps.saberEntityDist = 400;
 			self->client->ps.saberThrowTime = level.time;
 

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5257,6 +5257,9 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 			self->client->ps.saberEntityDist = 400;
 			self->client->ps.saberThrowTime = level.time;
 
+			// The saber should actually do something
+			cgi_Cvar_Set("g_saberRealisticCombat", "1");
+
 			//reset the mins
 			VectorCopy(saberMins, saberent->mins);
 			VectorCopy(saberMaxs, saberent->maxs);
@@ -5273,9 +5276,24 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 			// Don't do anything else with our saber, we're good here.
 			return;
 		}
-		else if (!self->client->ps.saberInFlight && cg.renderingThirdPerson && self->weaponModel == -1)
+		else if ((cg.renderingThirdPerson || self->client->ps.weapon != WP_SABER) && !self->client->ps.saberInFlight)
 		{
-			WP_SaberCatch(self, saberent, false);
+			//don't draw it
+			saberent->s.eFlags |= EF_NODRAW;
+			saberent->svFlags &= SVF_BROADCAST;
+			saberent->svFlags |= SVF_NOCLIENT;
+
+			//reset its contents/clipmask
+			saberent->contents = CONTENTS_LIGHTSABER;// | CONTENTS_SHOTCLIP;
+			saberent->clipmask = MASK_SHOT | CONTENTS_LIGHTSABER;
+
+			// We don't need this any more
+			cgi_Cvar_Set("g_saberRealisticCombat", "0");
+
+			if (self->client->ps.weapon == WP_SABER && self->weaponModel == -1)
+			{
+				G_CreateG2AttachedWeaponModel(self, self->client->ps.saberModel);
+			}
 		}
 	}
 

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5229,18 +5229,26 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 			GameHmd::Get()->GetRightHandPosition(vrR_pos[0], vrR_pos[1], vrR_pos[2]);
 			vrR_rot[YAW] += cg.refdefViewAnglesWeapon[YAW];
 
-			float c = cos(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
-			float s = sin(cg.refdefViewAnglesWeapon[YAW] * (M_PI / 180));
-
 			// Rotate saber to be in front of weapon view at all times
 			viewAnglesWeapon[PITCH] = 0.0f;
 			viewAnglesWeapon[ROLL] = 0.0f;
 			viewAnglesWeapon[YAW] = cg.refdefViewAnglesWeapon[YAW];
 			AnglesToAxis(viewAnglesWeapon, viewaxisWeapon);
 
-			VectorMA(pos, -(vrR_pos[0] * c - vrR_pos[1] * s), viewaxisWeapon[0], pos);
-			VectorMA(pos, -(vrR_pos[0] * s + vrR_pos[1] * c), viewaxisWeapon[1], pos);
+			VectorSet(pos, 0.0, 0.0, 0.0);
+			VectorMA(pos, -vrR_pos[0], viewaxisWeapon[0], pos);
+			VectorMA(pos, -vrR_pos[1], viewaxisWeapon[1], pos);
 			VectorMA(pos, -vrR_pos[2], viewaxisWeapon[2], pos);
+			VectorCopy(pos, vrR_pos);
+
+			// Rotate the gun around us according to our weapon view yaw
+			viewAnglesWeapon[YAW] = cg.refdefViewAnglesWeapon[YAW] - cg.refdef.delta_yaw;
+			AnglesToAxis(viewAnglesWeapon, viewaxisWeapon);
+
+			VectorSet(pos, 0.0, 0.0, 0.0);
+			VectorMA(pos, vrR_pos[0], viewaxisWeapon[0], pos);
+			VectorMA(pos, vrR_pos[1], viewaxisWeapon[1], pos);
+			VectorMA(pos, vrR_pos[2], viewaxisWeapon[2], pos);
 			VectorAdd(pos, cg.refdef.vieworg, pos);
 
 			// Place saber in the world

--- a/code/game/wp_saber.h
+++ b/code/game/wp_saber.h
@@ -20,6 +20,7 @@
 #define SES_LEAVING		1
 #define SES_HOVERING	2
 #define SES_RETURNING	3
+#define SES_OVERRIDE	4
 
 #define SABER_EXTRAPOLATE_DIST 16.0f
 


### PR DESCRIPTION
So this is my second take on tracking lightsabers to hands. My original PR I tried to unbolt the Ghoul2 saber from the playermodel hand and then have it offset and rotated to the hand position. This ended up having issues with animations and jitter, and also required some changes with Ghoul2.

For this PR the saber entity is used at all times in first-person mode, with its position and rotation overridden. Since its position and rotation aren't tied to any other models, it's much less janky and the implementation is cleaner.

Some general notes:

- Saber throw continues to function normally, though it still returns to the playermodel hand and not the controller hand
- In third-person mode, the saber is tied to the model and functions as usual.