### PR TITLE
Link force handling to hand positions/directions

### DIFF
--- a/code/cgame/cg_players.cpp
+++ b/code/cgame/cg_players.cpp
@@ -4880,6 +4880,8 @@ CG_Player
 
 ===============
 */
+
+extern void CG_CalculateWeaponPosition(vec3_t origin, vec3_t angles, bool rightHand);
 extern qboolean G_ControlledByPlayer( gentity_t *self );
 void CG_Player( centity_t *cent ) {
 	clientInfo_t	*ci;
@@ -5634,6 +5636,14 @@ extern vmCvar_t	cg_thirdPersonAlpha;
 					VectorSet( tAng, tempAngles[0]+cent->pe.torso.pitchAngle, tempAngles[1]+cent->pe.torso.yawAngle, 0 );
 				}
 				*/
+
+				// [shinyquagsire23] Render lightning for first-person saber at left hand location/rotation
+				if (cent->currentState.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
+				{
+					vec3_t vrL_rot;
+					CG_CalculateWeaponPosition(cent->gent->client->renderInfo.handLPoint, tAng, false);
+				}
+
 				if ( cent->gent->client->ps.forcePowerLevel[FP_LIGHTNING] > FORCE_LEVEL_2 )
 				{//arc
 					vec3_t	fxAxis[3];

--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -1016,6 +1016,12 @@ void CG_AddViewWeapon( playerState_t *ps )
 
 		VectorCopy( cent->gent->client->renderInfo.handLPoint, temp );
 		VectorMA( temp, -5, cg.refdef.viewaxis[0], temp );
+
+		// [shinyquagsire23] Render lightning for first-person saber at left hand location/rotation
+		if (GameHmd::Get()->HasHands())
+		{
+			CG_CalculateWeaponPosition(temp, tAng, false);
+		}
 		if ( cent->gent->client->ps.forcePowerLevel[FP_LIGHTNING] > FORCE_LEVEL_2 )
 		{//arc
 			vec3_t	fxAxis[3];

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -7084,6 +7084,14 @@ void ForceGrip( gentity_t *self )
 
 	AngleVectors( self->client->ps.viewangles, forward, NULL, NULL );
 	VectorNormalize( forward );
+
+	// [shinyquagsire23] Trace from the left hand when available
+	if (self->s.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
+	{
+		vec3_t vrL_rot;
+		CG_CalculateWeaponPosition(self->client->renderInfo.handLPoint, vrL_rot, false);
+		AngleVectors(vrL_rot, forward, NULL, NULL);
+	}
 	VectorMA( self->client->renderInfo.handLPoint, FORCE_GRIP_DIST, forward, end );
 	
 	if ( self->enemy && (self->s.number || InFront( self->enemy->currentOrigin, self->client->renderInfo.eyePoint, self->client->ps.viewangles, 0.2f ) ) ) 
@@ -8273,7 +8281,12 @@ static void WP_ForcePowerRun( gentity_t *self, forcePowers_t forcePower, usercmd
 				angles[0] -= 10;
 				AngleVectors( angles, dir, NULL, NULL );
 
-
+				// [shinyquagsire23] Control grip from left hand when available
+				if (self->s.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
+				{
+					CG_CalculateWeaponPosition(self->client->renderInfo.handLPoint, angles, false);
+					AngleVectors(angles, dir, NULL, NULL);
+				}
 
 				if ( gripEnt->client )
 				{//move

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5211,7 +5211,7 @@ void WP_SaberUpdate( gentity_t *self, usercmd_t *ucmd )
 	saberent = &g_entities[self->client->ps.saberEntityNum];
 
 	// [shinyquagsire23] Bind a saber to our right hand position in first-person mode
-	if (self->s.number == 0 && GameHmd::Get()->HasHands())
+	if (self->s.number == 0 && GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
 	{
 		if (!cg.renderingThirdPerson && !self->client->ps.saberInFlight && self->client->ps.weapon == WP_SABER)
 		{
@@ -7424,7 +7424,7 @@ void ForceShootLightning( gentity_t *self )
 	VectorNormalize( forward );
 
 	// [shinyquagsire23] Shoot lightning at position and direction of left hand
-	if (self->s.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands())
+	if (self->s.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
 	{
 		vec3_t vrL_rot;
 		CG_CalculateWeaponPosition(self->client->renderInfo.handLPoint, vrL_rot, false);

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -99,6 +99,8 @@ void ForceThrow( gentity_t *self, qboolean pull );
 qboolean WP_ForcePowerAvailable( gentity_t *self, forcePowers_t forcePower, int overrideAmt );
 void WP_ForcePowerDrain( gentity_t *self, forcePowers_t forcePower, int overrideAmt );
 
+extern void CG_CalculateWeaponPosition(vec3_t origin, vec3_t angles, bool rightHand);
+
 extern cvar_t	*g_saberAutoBlocking;
 extern cvar_t	*g_saberRealisticCombat;
 extern int g_crosshairEntNum;
@@ -7412,6 +7414,15 @@ void ForceShootLightning( gentity_t *self )
 
 	AngleVectors( self->client->ps.viewangles, forward, NULL, NULL );
 	VectorNormalize( forward );
+
+	// [shinyquagsire23] Shoot lightning at position and direction of left hand
+	if (GameHmd::Get()->HasHands())
+	{
+		vec3_t vrL_rot;
+		CG_CalculateWeaponPosition(self->client->renderInfo.handLPoint, vrL_rot, false);
+		AngleVectors(vrL_rot, forward, NULL, NULL);
+		VectorNormalize(forward);
+	}
 
 	//FIXME: if lightning hits water, do water-only-flagged radius damage from that point
 	if ( self->client->ps.forcePowerLevel[FP_LIGHTNING] > FORCE_LEVEL_2 )

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -7416,7 +7416,7 @@ void ForceShootLightning( gentity_t *self )
 	VectorNormalize( forward );
 
 	// [shinyquagsire23] Shoot lightning at position and direction of left hand
-	if (GameHmd::Get()->HasHands())
+	if (self->s.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands())
 	{
 		vec3_t vrL_rot;
 		CG_CalculateWeaponPosition(self->client->renderInfo.handLPoint, vrL_rot, false);
@@ -8272,6 +8272,9 @@ static void WP_ForcePowerRun( gentity_t *self, forcePowers_t forcePower, usercmd
 				VectorCopy( self->client->ps.viewangles, angles );
 				angles[0] -= 10;
 				AngleVectors( angles, dir, NULL, NULL );
+
+
+
 				if ( gripEnt->client )
 				{//move
 					VectorCopy( gripEnt->client->renderInfo.headPoint, gripEntOrg );

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -5846,6 +5846,13 @@ void ForceThrow( gentity_t *self, qboolean pull )
 #endif // _IMMERSION
 
 	VectorCopy( self->client->ps.viewangles, fwdangles );
+
+	// [shinyquagsire23] Get angles from the left hand when available
+	if (self->s.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
+	{
+		CG_CalculateWeaponPosition(self->client->renderInfo.handLPoint, fwdangles, false);
+	}
+
 	//fwdangles[1] = self->client->ps.viewangles[1];
 	AngleVectors( fwdangles, forward, right, NULL );
 	VectorCopy( self->currentOrigin, center );
@@ -5878,6 +5885,14 @@ void ForceThrow( gentity_t *self, qboolean pull )
 			return;
 		}
 		*/
+
+		// [shinyquagsire23] Trace from the left hand when available
+		if (self->s.number == cg.snap->ps.clientNum && GameHmd::Get()->HasHands() && !cg.renderingThirdPerson)
+		{
+			VectorMA(self->client->renderInfo.handLPoint, radius, forward, end);
+			gi.trace(&tr, self->client->renderInfo.handLPoint, vec3_origin, vec3_origin, end, self->s.number, MASK_OPAQUE | CONTENTS_SOLID | CONTENTS_BODY | CONTENTS_ITEM | CONTENTS_CORPSE, (EG2_Collision)0, 0);//was MASK_SHOT, changed to match crosshair trace
+		}
+
 		forwardEnt = &g_entities[tr.entityNum];
 	}
 


### PR DESCRIPTION
Binds force powers to use the actual left hand instead of the playermodel left hand. I might try and see if I can expand the lenience with grip/mind trick since it's actually a bit hard to do without the debug view. Everything else is pretty solid though. Saber throw still follows the player view, need to work that out for completeness but otherwise everything else seems fine.

[Grip example](https://twitter.com/ShinyQuagsire/status/960384512696795136)